### PR TITLE
Updated readme go get link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Note that the funcs compile regexes, so avoid calling them repeatedly.
 
 #### cmd/xurls
 
-	go get -u mvdan.cc/xurls/v2/cmd/xurls
+	go get -u github.com/mvdan/xurls
 
 ```shell
 $ echo "Do gophers live in http://golang.org?" | xurls


### PR DESCRIPTION
The current `go get` link does not work so I have changed it to a github one.