### PR TITLE
Add underscore to endchar

### DIFF
--- a/xurls.go
+++ b/xurls.go
@@ -19,7 +19,7 @@ const (
 	iriChar   = letter + mark + number
 	currency  = `\p{Sc}`
 	otherSymb = `\p{So}`
-	endChar   = iriChar + `/\-+&~%=#` + currency + otherSymb
+	endChar   = iriChar + `/\-_+&~%=#` + currency + otherSymb
 	otherPunc = `\p{Po}`
 	midChar   = endChar + "_*" + otherPunc
 	wellParen = `\([` + midChar + `]*(\([` + midChar + `]*\)[` + midChar + `]*)*\)`

--- a/xurls_test.go
+++ b/xurls_test.go
@@ -102,7 +102,7 @@ var constantTestCases = []testCase{
 	{`,http://foo.com/bar,more`, `http://foo.com/bar,more`},
 	{`*http://foo.com/bar*`, `http://foo.com/bar`},
 	{`*http://foo.com/bar*more`, `http://foo.com/bar*more`},
-	{`_http://foo.com/bar_`, `http://foo.com/bar`},
+	{`_http://foo.com/bar_`, `http://foo.com/bar_`},
 	{`_http://foo.com/bar_more`, `http://foo.com/bar_more`},
 	{`(http://foo.com/bar)`, `http://foo.com/bar`},
 	{`(http://foo.com/bar)more`, `http://foo.com/bar`},


### PR DESCRIPTION
Some urls at the end have underscore like [https://www.youtube.com/watch?v=XUaMuKf7xGs&list=PLFpTpXRVicw-CYx-zDCci-AkE2NaEA3a_](https://www.youtube.com/watch?v=XUaMuKf7xGs&list=PLFpTpXRVicw-CYx-zDCci-AkE2NaEA3a_)