### PR TITLE
Fix install command to lack of v2 suffix and switch to mvdan way

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Note that the funcs compile regexes, so avoid calling them repeatedly.
 
 To install the tool globally:
 
-	go get mvdan.cc/xurls/cmd/xurls
+	cd $(mktemp -d); go mod init tmp; GO111MODULE=on go get mvdan.cc/xurls/v2/cmd/xurls
 
 ```shell
 $ echo "Do gophers live in http://golang.org?" | xurls


### PR DESCRIPTION
Add `/v2` suffix for `xurls` command should fetch from the `mvdan.cc/xurls/v2` module root.
Actually, revert 795eb0c58b17f3db55c9b06d4a5bbc753199858a because the no longer supports Go version 1.11 and earlier on e21d637d7b83784a55a9ad577f035e72d72fa927. (Also said _Requires Go 1.12 or later._ on follows.)
<img width="400" alt="Screen Shot 2019-12-27 at 9 31 04 PM" src="https://user-images.githubusercontent.com/6366270/71517183-3e420e80-28f0-11ea-8c69-7db985f8f1f5.png">

Also, like [mvdan/gofumpt](https://github.com/mvdan/gofumpt), switch to use `mktmp` way.