### PR TITLE
Update schemes

### DIFF
--- a/xurls.go
+++ b/xurls.go
@@ -62,12 +62,14 @@ var SchemesNoAuthority = []string{
 //
 // Mostly collected from https://en.wikipedia.org/wiki/List_of_URI_schemes#Unofficial_but_common_URI_schemes.
 var SchemesUnofficial = []string{
-	`jdbc`,       // Java database Connectivity
-	`postgres`,   // PostgreSQL (short form)
-	`postgresql`, // PostgreSQL
-	`slack`,      // Slack
-	`zoommtg`,    // Zoom (desktop)
-	`zoomus`,     // Zoom (mobile)
+	`gemini`,        // gemini
+	`jdbc`,          // Java database Connectivity
+	`moz-extension`, // Firefox extension
+	`postgres`,      // PostgreSQL (short form)
+	`postgresql`,    // PostgreSQL
+	`slack`,         // Slack
+	`zoommtg`,       // Zoom (desktop)
+	`zoomus`,        // Zoom (mobile)
 }
 
 func anyOf(strs ...string) string {


### PR DESCRIPTION
Add gemini:// and moz-extension:// schemes.

moz-extension:// is used by Firefox addons. People using FF devtools
frequently end up copying moz-extension URLs, so it might make sense to
include their scheme.

gemini:// is a new protocol for a network that sits somewhere between
Gopher and the WWW. Although not registered with the IANA yet, it does
have an acative community that shares a lot of gemini:// links in various
places. xurls should recognize these. More info at
https://gemini.circumlunar.space and gemini://gemini.circumlunar.space.