### PR TITLE
optimize regular expressions

### DIFF
--- a/xurls.go
+++ b/xurls.go
@@ -81,6 +81,9 @@ var SchemesUnofficial = []string{
 	`zoomus`,        // Zoom (mobile)
 }
 
+var strictRe = regexp.MustCompile(strictExp())
+var relaxedRe = regexp.MustCompile(relaxedExp())
+
 func anyOf(strs ...string) string {
 	var b strings.Builder
 	b.WriteByte('(')
@@ -125,17 +128,15 @@ func relaxedExp() string {
 // Strict produces a regexp that matches any URL with a scheme in either the
 // Schemes or SchemesNoAuthority lists.
 func Strict() *regexp.Regexp {
-	re := regexp.MustCompile(strictExp())
-	re.Longest()
-	return re
+	strictRe.Longest()
+	return strictRe.Copy()
 }
 
 // Relaxed produces a regexp that matches any URL matched by Strict, plus any
 // URL with no scheme or email address.
 func Relaxed() *regexp.Regexp {
-	re := regexp.MustCompile(relaxedExp())
-	re.Longest()
-	return re
+	relaxedRe.Longest()
+	return relaxedRe.Copy()
 }
 
 // StrictMatchingScheme produces a regexp similar to Strict, but requiring that

--- a/xurls.go
+++ b/xurls.go
@@ -28,23 +28,23 @@ const (
 	iPrivateChar        = `\x{E000}-\x{F8FF}\x{F0000}-\x{FFFFD}\x{100000}-\x{10FFFD}`
 	midIChar            = `/?#\\` + midIPathSegmentChar + iPrivateChar
 	endIChar            = `/#` + endIPathSegmentChar + iPrivateChar
-	wellParen           = `\(([` + midIChar + `]|\([` + midIChar + `]*\))*\)`
-	wellBrack           = `\[([` + midIChar + `]|\[[` + midIChar + `]*\])*\]`
-	wellBrace           = `\{([` + midIChar + `]|\{[` + midIChar + `]*\})*\}`
+	wellParen           = `\((?:[` + midIChar + `]|\([` + midIChar + `]*\))*\)`
+	wellBrack           = `\[(?:[` + midIChar + `]|\[[` + midIChar + `]*\])*\]`
+	wellBrace           = `\{(?:[` + midIChar + `]|\{[` + midIChar + `]*\})*\}`
 	wellAll             = wellParen + `|` + wellBrack + `|` + wellBrace
-	pathCont            = `([` + midIChar + `]*(` + wellAll + `|[` + endIChar + `]))+`
+	pathCont            = `(?:[` + midIChar + `]*(?:` + wellAll + `|[` + endIChar + `]))+`
 
 	letter   = `\p{L}`
 	mark     = `\p{M}`
 	number   = `\p{N}`
 	iriChar  = letter + mark + number
-	iri      = `[` + iriChar + `]([` + iriChar + `\-]*[` + iriChar + `])?`
-	domain   = `(` + iri + `\.)+`
+	iri      = `[` + iriChar + `](?:[` + iriChar + `\-]*[` + iriChar + `])?`
+	domain   = `(?:` + iri + `\.)+`
 	octet    = `(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])`
 	ipv4Addr = `\b` + octet + `\.` + octet + `\.` + octet + `\.` + octet + `\b`
-	ipv6Addr = `([0-9a-fA-F]{1,4}:([0-9a-fA-F]{1,4}:([0-9a-fA-F]{1,4}:([0-9a-fA-F]{1,4}:([0-9a-fA-F]{1,4}:[0-9a-fA-F]{0,4}|:[0-9a-fA-F]{1,4})?|(:[0-9a-fA-F]{1,4}){0,2})|(:[0-9a-fA-F]{1,4}){0,3})|(:[0-9a-fA-F]{1,4}){0,4})|:(:[0-9a-fA-F]{1,4}){0,5})((:[0-9a-fA-F]{1,4}){2}|:(25[0-5]|(2[0-4]|1[0-9]|[1-9])?[0-9])(\.(25[0-5]|(2[0-4]|1[0-9]|[1-9])?[0-9])){3})|(([0-9a-fA-F]{1,4}:){1,6}|:):[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){7}:`
-	ipAddr   = `(` + ipv4Addr + `|` + ipv6Addr + `)`
-	port     = `(:[0-9]*)?`
+	ipv6Addr = `(?:[0-9a-fA-F]{1,4}:(?:[0-9a-fA-F]{1,4}:(?:[0-9a-fA-F]{1,4}:(?:[0-9a-fA-F]{1,4}:(?:[0-9a-fA-F]{1,4}:[0-9a-fA-F]{0,4}|:[0-9a-fA-F]{1,4})?|(?::[0-9a-fA-F]{1,4}){0,2})|(?::[0-9a-fA-F]{1,4}){0,3})|(?::[0-9a-fA-F]{1,4}){0,4})|:(?::[0-9a-fA-F]{1,4}){0,5})(?:(?::[0-9a-fA-F]{1,4}){2}|:(?:25[0-5]|(?:2[0-4]|1[0-9]|[1-9])?[0-9])(?:\.(?:25[0-5]|(?:2[0-4]|1[0-9]|[1-9])?[0-9])){3})|(?:(?:[0-9a-fA-F]{1,4}:){1,6}|:):[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){7}:`
+	ipAddr   = `(?:` + ipv4Addr + `|` + ipv6Addr + `)`
+	port     = `(?::[0-9]*)?`
 )
 
 // AnyScheme can be passed to StrictMatchingScheme to match any possibly valid

--- a/xurls.go
+++ b/xurls.go
@@ -28,11 +28,11 @@ const (
 	iPrivateChar        = `\x{E000}-\x{F8FF}\x{F0000}-\x{FFFFD}\x{100000}-\x{10FFFD}`
 	midIChar            = `/?#\\` + midIPathSegmentChar + iPrivateChar
 	endIChar            = `/#` + endIPathSegmentChar + iPrivateChar
-	wellParen           = `\([` + midIChar + `]*(\([` + midIChar + `]*\)[` + midIChar + `]*)*\)`
-	wellBrack           = `\[[` + midIChar + `]*(\[[` + midIChar + `]*\][` + midIChar + `]*)*\]`
-	wellBrace           = `\{[` + midIChar + `]*(\{[` + midIChar + `]*\}[` + midIChar + `]*)*\}`
+	wellParen           = `\(([` + midIChar + `]|\([` + midIChar + `]*\))*\)`
+	wellBrack           = `\[([` + midIChar + `]|\[[` + midIChar + `]*\])*\]`
+	wellBrace           = `\{([` + midIChar + `]|\{[` + midIChar + `]*\})*\}`
 	wellAll             = wellParen + `|` + wellBrack + `|` + wellBrace
-	pathCont            = `([` + midIChar + `]*(` + wellAll + `|[` + endIChar + `])+)+`
+	pathCont            = `([` + midIChar + `]*(` + wellAll + `|[` + endIChar + `]))+`
 
 	letter   = `\p{L}`
 	mark     = `\p{M}`

--- a/xurls.go
+++ b/xurls.go
@@ -86,7 +86,7 @@ var relaxedRe = regexp.MustCompile(relaxedExp())
 
 func anyOf(strs ...string) string {
 	var b strings.Builder
-	b.WriteByte('(')
+	b.WriteString("(?:")
 	for i, s := range strs {
 		if i != 0 {
 			b.WriteByte('|')
@@ -98,7 +98,7 @@ func anyOf(strs ...string) string {
 }
 
 func strictExp() string {
-	schemes := `((` + anyOf(Schemes...) + `|` + anyOf(SchemesUnofficial...) + `)://|` + anyOf(SchemesNoAuthority...) + `:)`
+	schemes := `(?:(?:` + anyOf(Schemes...) + `|` + anyOf(SchemesUnofficial...) + `)://|` + anyOf(SchemesNoAuthority...) + `:)`
 	return `(?i)` + schemes + `(?-i)` + pathCont
 }
 
@@ -116,11 +116,11 @@ func relaxedExp() string {
 	// Use \b to make sure ASCII TLDs are immediately followed by a word break.
 	// We can't do that with unicode TLDs, as they don't see following
 	// whitespace as a word break.
-	tlds := `(?i)(` + punycode + `|` + anyOf(append(asciiTLDs, PseudoTLDs...)...) + `\b|` + anyOf(unicodeTLDs...) + `)(?-i)`
+	tlds := `(?i)(?:` + punycode + `|` + anyOf(append(asciiTLDs, PseudoTLDs...)...) + `\b|` + anyOf(unicodeTLDs...) + `)(?-i)`
 	site := domain + tlds
 
-	hostName := `(` + site + `|` + ipAddr + `)`
-	webURL := hostName + port + `(/|/` + pathCont + `)?`
+	hostName := `(?:` + site + `|` + ipAddr + `)`
+	webURL := hostName + port + `(?:/` + pathCont + `|/)?`
 	email := `[a-zA-Z0-9._%\-+]+@` + site
 	return strictExp() + `|` + webURL + `|` + email
 }


### PR DESCRIPTION
`benchstat` vs. master@588e8594267cca0d170ceda20342f7a883b80153:

    name             old time/op    new time/op    delta
    StrictEmpty-4      15.0ns ± 1%    14.9ns ± 1%   -0.51%  (p=0.004 n=7+10)
    StrictSingle-4     41.2µs ± 4%    34.2µs ± 2%  -17.08%  (p=0.000 n=10+10)
    StrictMany-4        125µs ± 1%     105µs ± 2%  -15.80%  (p=0.000 n=10+10)
    RelaxedEmpty-4     15.2µs ± 3%     9.9µs ± 1%  -35.01%  (p=0.000 n=10+10)
    RelaxedSingle-4    95.3µs ± 5%    57.8µs ± 1%  -39.29%  (p=0.000 n=10+10)
    RelaxedMany-4       247µs ± 1%     156µs ± 2%  -36.71%  (p=0.000 n=9+10)

    name             old alloc/op   new alloc/op   delta
    StrictEmpty-4       0.00B          0.00B          ~     (all equal)
    StrictSingle-4       364B ± 4%      187B ±15%  -48.58%  (p=0.000 n=9+10)
    StrictMany-4         792B ± 6%      241B ±14%  -69.59%  (p=0.000 n=10+10)
    RelaxedEmpty-4      73.8B ± 2%     1.5B ±233%  -97.97%  (p=0.000 n=10+10)
    RelaxedSingle-4    2.43kB ± 4%    0.34kB ±13%  -86.02%  (p=0.000 n=9+10)
    RelaxedMany-4      5.02kB ± 3%    0.54kB ±22%  -89.18%  (p=0.000 n=10+10)

    name             old allocs/op  new allocs/op  delta
    StrictEmpty-4        0.00           0.00          ~     (all equal)
    StrictSingle-4       2.00 ± 0%      2.00 ± 0%     ~     (all equal)
    StrictMany-4         4.00 ± 0%      4.00 ± 0%     ~     (all equal)
    RelaxedEmpty-4       0.00           0.00          ~     (all equal)
    RelaxedSingle-4      4.00 ± 0%      3.00 ± 0%  -25.00%  (p=0.000 n=10+10)
    RelaxedMany-4        8.00 ± 0%      5.00 ± 0%  -37.50%  (p=0.002 n=8+10)