### PR TITLE
add support for bracketed IPv6 addresses in the IRI authority component

### DIFF
--- a/xurls.go
+++ b/xurls.go
@@ -21,10 +21,12 @@ const (
 	// to avoid creating asymmetries like
 	// `Did you know that **<a href="...">https://example.com/**</a> is reserved for documentation?`
 	// from `Did you know that **https://example.com/** is reserved for documentation?`.
+	unreservedChar      = `a-zA-Z0-9\-._~`
+	endUnreservedChar   = `a-zA-Z0-9\-_~`
 	midSubDelimChar     = `!$&'*+,;=`
 	endSubDelimChar     = `$&+=`
-	midIPathSegmentChar = `a-zA-Z0-9\-._~` + `%` + midSubDelimChar + `:@` + allowedUcsChar
-	endIPathSegmentChar = `a-zA-Z0-9\-_~` + `%` + endSubDelimChar + allowedUcsCharMinusPunc
+	midIPathSegmentChar = unreservedChar + `%` + midSubDelimChar + `:@` + allowedUcsChar
+	endIPathSegmentChar = endUnreservedChar + `%` + endSubDelimChar + allowedUcsCharMinusPunc
 	iPrivateChar        = `\x{E000}-\x{F8FF}\x{F0000}-\x{FFFFD}\x{100000}-\x{10FFFD}`
 	midIChar            = `/?#\\` + midIPathSegmentChar + iPrivateChar
 	endIChar            = `/#` + endIPathSegmentChar + iPrivateChar
@@ -34,17 +36,46 @@ const (
 	wellAll             = wellParen + `|` + wellBrack + `|` + wellBrace
 	pathCont            = `(?:[` + midIChar + `]*(?:` + wellAll + `|[` + endIChar + `]))+`
 
-	letter   = `\p{L}`
-	mark     = `\p{M}`
-	number   = `\p{N}`
-	iriChar  = letter + mark + number
-	iri      = `[` + iriChar + `](?:[` + iriChar + `\-]*[` + iriChar + `])?`
-	domain   = `(?:` + iri + `\.)+`
-	octet    = `(?:25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])`
-	ipv4Addr = `\b` + octet + `\.` + octet + `\.` + octet + `\.` + octet + `\b`
-	ipv6Addr = `(?:[0-9a-fA-F]{1,4}:(?:[0-9a-fA-F]{1,4}:(?:[0-9a-fA-F]{1,4}:(?:[0-9a-fA-F]{1,4}:(?:[0-9a-fA-F]{1,4}:[0-9a-fA-F]{0,4}|:[0-9a-fA-F]{1,4})?|(?::[0-9a-fA-F]{1,4}){0,2})|(?::[0-9a-fA-F]{1,4}){0,3})|(?::[0-9a-fA-F]{1,4}){0,4})|:(?::[0-9a-fA-F]{1,4}){0,5})(?:(?::[0-9a-fA-F]{1,4}){2}|:(?:25[0-5]|(?:2[0-4]|1[0-9]|[1-9])?[0-9])(?:\.(?:25[0-5]|(?:2[0-4]|1[0-9]|[1-9])?[0-9])){3})|(?:(?:[0-9a-fA-F]{1,4}:){1,6}|:):[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){7}:`
-	ipAddr   = `(?:` + ipv4Addr + `|` + ipv6Addr + `)`
-	port     = `(?::[0-9]*)?`
+	letter    = `\p{L}`
+	mark      = `\p{M}`
+	number    = `\p{N}`
+	iriChar   = letter + mark + number
+	iri       = `[` + iriChar + `](?:[` + iriChar + `\-]*[` + iriChar + `])?`
+	subdomain = `(?:` + iri + `\.)+`
+	octet     = `(?:25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])`
+	ipv4Addr  = octet + `\.` + octet + `\.` + octet + `\.` + octet
+
+	// ipv6Addr is based on https://datatracker.ietf.org/doc/html/rfc4291#section-2.2
+	// with a specific alternative for each valid count of leading 16-bit hexadecimal "chomps"
+	// that have not been replaced with a `::` elision.
+	h4                 = `[0-9a-fA-F]{1,4}`
+	ipv6AddrMinusEmpty = `(?:` +
+		// 7 colon-terminated chomps, followed by a final chomp or the rest of an elision.
+		`(?:` + h4 + `:){7}(?:` + h4 + `|:)|` +
+		// 6 chomps, followed by an IPv4 address or elision with final chomp or final elision.
+		`(?:` + h4 + `:){6}(?:` + ipv4Addr + `|:` + h4 + `|:)|` +
+		// 5 chomps, followed by an elision with optional IPv4 or up to 2 final chomps.
+		`(?:` + h4 + `:){5}(?::` + ipv4Addr + `|(?::` + h4 + `){1,2}|:)|` +
+		// 4 chomps, followed by an elision with optional IPv4 (optionally preceded by a chomp) or
+		// up to 3 final chomps.
+		`(?:` + h4 + `:){4}(?:(?::` + h4 + `){0,1}:` + ipv4Addr + `|(?::` + h4 + `){1,3}|:)|` +
+		// 3 chomps, followed by an elision with optional IPv4 (preceded by up to 2 chomps) or
+		// up to 4 final chomps.
+		`(?:` + h4 + `:){3}(?:(?::` + h4 + `){0,2}:` + ipv4Addr + `|(?::` + h4 + `){1,4}|:)|` +
+		// 2 chomps, followed by an elision with optional IPv4 (preceded by up to 3 chomps) or
+		// up to 5 final chomps.
+		`(?:` + h4 + `:){2}(?:(?::` + h4 + `){0,3}:` + ipv4Addr + `|(?::` + h4 + `){1,5}|:)|` +
+		// 1 chomp, followed by an elision with optional IPv4 (preceded by up to 4 chomps) or
+		// up to 6 final chomps.
+		`(?:` + h4 + `:){1}(?:(?::` + h4 + `){0,4}:` + ipv4Addr + `|(?::` + h4 + `){1,6}|:)|` +
+		// elision, followed by optional IPv4 (preceded by up to 5 chomps) or
+		// up to 7 final chomps.
+		// `:` is an intentionally omitted alternative, to avoid matching `::`.
+		`:(?:(?::` + h4 + `){0,5}:` + ipv4Addr + `|(?::` + h4 + `){1,7})` +
+		`)`
+	ipv6Addr         = `(?:` + ipv6AddrMinusEmpty + `|::)`
+	ipAddrMinusEmpty = `(?:` + ipv6AddrMinusEmpty + `|\b` + ipv4Addr + `\b)`
+	port             = `(?::[0-9]*)?`
 )
 
 // AnyScheme can be passed to StrictMatchingScheme to match any possibly valid
@@ -109,8 +140,8 @@ func anyOf(strs ...string) string {
 }
 
 func strictExp() string {
-	schemes := `(?:(?:` + anyOf(Schemes...) + `|` + anyOf(SchemesUnofficial...) + `)://|` + anyOf(SchemesNoAuthority...) + `:)`
-	return `(?i)` + schemes + `(?-i)` + pathCont
+	schemes := `(?:(?i)(?:` + anyOf(Schemes...) + `|` + anyOf(SchemesUnofficial...) + `)://|` + anyOf(SchemesNoAuthority...) + `:)`
+	return schemes + pathCont
 }
 
 func relaxedExp() string {
@@ -127,12 +158,12 @@ func relaxedExp() string {
 	// Use \b to make sure ASCII TLDs are immediately followed by a word break.
 	// We can't do that with unicode TLDs, as they don't see following
 	// whitespace as a word break.
-	tlds := `(?i)(?:` + punycode + `|` + anyOf(append(asciiTLDs, PseudoTLDs...)...) + `\b|` + anyOf(unicodeTLDs...) + `)(?-i)`
-	site := domain + tlds
+	tlds := `(?:(?i)` + punycode + `|` + anyOf(append(asciiTLDs, PseudoTLDs...)...) + `\b|` + anyOf(unicodeTLDs...) + `)`
+	domain := subdomain + tlds
 
-	hostName := `(?:` + site + `|` + ipAddr + `)`
+	hostName := `(?:` + domain + `|` + ipAddrMinusEmpty + `)`
 	webURL := hostName + port + `(?:/` + pathCont + `|/)?`
-	email := `[a-zA-Z0-9._%\-+]+@` + site
+	email := `[a-zA-Z0-9._%\-+]+@` + domain
 	return strictExp() + `|` + webURL + `|` + email
 }
 

--- a/xurls.go
+++ b/xurls.go
@@ -161,10 +161,10 @@ func relaxedExp() string {
 	tlds := `(?:(?i)` + punycode + `|` + anyOf(append(asciiTLDs, PseudoTLDs...)...) + `\b|` + anyOf(unicodeTLDs...) + `)`
 	domain := subdomain + tlds
 
-	hostName := `(?:` + domain + `|` + ipAddrMinusEmpty + `)`
+	hostName := `(?:` + domain + `|\[` + ipv6Addr + `\]|\b` + ipv4Addr + `\b)`
 	webURL := hostName + port + `(?:/` + pathCont + `|/)?`
 	email := `[a-zA-Z0-9._%\-+]+@` + domain
-	return strictExp() + `|` + webURL + `|` + email
+	return strictExp() + `|` + webURL + `|` + email + `|` + ipv6AddrMinusEmpty
 }
 
 // Strict produces a regexp that matches any URL with a scheme in either the

--- a/xurls_test.go
+++ b/xurls_test.go
@@ -299,6 +299,7 @@ func TestRegexes(t *testing.T) {
 
 		// An IP address in URI host position must be bracketed unless it is IPv4.
 		// https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2
+		// TODO: Implement this restriction, ideally without matching the `http://1080` prefix.
 		//{`http://1080::8:800:200c:417a/path`, `1080::8:800:200c:417a`},
 
 		{`foo.com:8080`, true},
@@ -353,6 +354,7 @@ func TestRegexes(t *testing.T) {
 
 		// An IP address in URI host position must be bracketed unless it is IPv4.
 		// https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2
+		// TODO: Implement this restriction, ideally without matching the `http://1080` prefix.
 		//{`http://1080::8:800:200c:417a/path`, nil},
 	})
 }

--- a/xurls_test.go
+++ b/xurls_test.go
@@ -166,7 +166,14 @@ var constantTestCases = []testCase{
 	{`http://foo.com/path`, true},
 	{`http://foo.com:8080/path`, true},
 	{`http://1.1.1.1/path`, true},
+	{`http://1.1.1.1:8080/path`, true},
+	{`http://[1080::8:800:200c:417a]/path`, true},
+	{`http://[1080::8:800:200c:417a]:8080/path`, true},
+
+	// scheme://IPv6_addr is not valid per RFC 3987, but is supported anyway (for now).
 	{`http://1080::8:800:200c:417a/path`, true},
+	{`http://2001.db8:0/path`, true},
+
 	{`http://中国.中国/中国`, true},
 	{`http://中国.中国/foo中国`, true},
 	{`http://उदाहरण.परीकषा`, true},
@@ -220,9 +227,80 @@ func TestRegexes(t *testing.T) {
 		{`300.1.1.1`, nil},
 		{`1.1.1.300`, nil},
 		{`foo@1.2.3.4`, `1.2.3.4`},
-		{`1080:0:0:0:8:800:200C:4171`, true},
-		{`3ffe:2a00:100:7031::1`, true},
-		{`1080::8:800:200c:417a`, true},
+
+		// https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
+		{`::1`, true},
+		//{`::`, true},
+		{`::ffff:0:0`, true},
+		{`64:ff9b::`, true},
+		{`64:ff9b:1::`, true},
+		{`100::`, true},
+		{`2001::`, true},
+		{`2001:1::1`, true},
+		{`2001:1::2`, true},
+		{`2001:2::`, true},
+		{`2001:3::`, true},
+		{`2001:4:112::`, true},
+		{`2001:10::`, true},
+		{`2001:20::`, true},
+		{`2001:db8::`, true},
+		{`2002::`, true},
+		{`2620:4f:8000::`, true},
+		{`fc00::`, true},
+		{`fe80::`, true},
+
+		// https://datatracker.ietf.org/doc/html/rfc4291#section-2.2
+		{`ABCD:EF01:2345:6789:ABCD:EF01:2345:6789`, true},
+		{`2001:DB8:0:0:8:800:200C:417A`, true},
+		{`2001:DB8:0:0:8:800:200C:417A`, true}, // a unicast address
+		{`FF01:0:0:0:0:0:0:101`, true},         // a multicast address
+		{`0:0:0:0:0:0:0:1`, true},              // the loopback address
+		{`0:0:0:0:0:0:0:0`, true},              // the unspecified address
+		{`2001:DB8::8:800:200C:417A`, true},    // a unicast address
+		{`FF01::101`, true},                    // a multicast address
+		{`::1`, true},                          // the loopback address
+		//{`::`, true},                         // the unspecified address
+		{`::`, nil},
+		{`0:0:0:0:0:0:13.1.68.3`, true},
+		{`0:0:0:0:0:FFFF:129.144.52.38`, true},
+		{`::13.1.68.3`, true},
+		{`::FFFF:129.144.52.38`, true},
+
+		// https://datatracker.ietf.org/doc/html/rfc5952#section-1
+		{`2001:db8:0:0:1:0:0:1`, true},
+		{`2001:0db8:0:0:1:0:0:1`, true},
+		{`2001:db8::1:0:0:1`, true},
+		{`2001:db8::0:1:0:0:1`, true},
+		{`2001:0db8::1:0:0:1`, true},
+		{`2001:db8:0:0:1::1`, true},
+		{`2001:db8:0000:0:1::1`, true},
+		{`2001:DB8:0:0:1::1`, true},
+
+		// https://datatracker.ietf.org/doc/html/rfc5952#section-2.1
+		{`2001:db8:aaaa:bbbb:cccc:dddd:eeee:0001`, true},
+		{`2001:db8:aaaa:bbbb:cccc:dddd:eeee:001`, true},
+		{`2001:db8:aaaa:bbbb:cccc:dddd:eeee:01`, true},
+		{`2001:db8:aaaa:bbbb:cccc:dddd:eeee:1`, true},
+
+		// https://datatracker.ietf.org/doc/html/rfc5952#section-2.2
+		{`2001:db8:aaaa:bbbb:cccc:dddd::1`, true},
+		{`2001:db8:aaaa:bbbb:cccc:dddd:0:1`, true},
+		{`2001:db8:0:0:0::1`, true},
+		{`2001:db8:0:0::1`, true},
+		{`2001:db8:0::1`, true},
+		{`2001:db8::1`, true},
+		{`2001:db8::aaaa:0:0:1`, true},
+		{`2001:db8:0:0:aaaa::1`, true},
+
+		// https://datatracker.ietf.org/doc/html/rfc5952#section-2.3
+		{`2001:db8:aaaa:bbbb:cccc:dddd:eeee:aaaa`, true},
+		{`2001:db8:aaaa:bbbb:cccc:dddd:eeee:AAAA`, true},
+		{`2001:db8:aaaa:bbbb:cccc:dddd:eeee:AaAa`, true},
+
+		// An IP address in URI host position must be bracketed unless it is IPv4.
+		// https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2
+		//{`http://1080::8:800:200c:417a/path`, `1080::8:800:200c:417a`},
+
 		{`foo.com:8080`, true},
 		{`foo.com:8080/path`, true},
 		{`test.foo.com`, true},
@@ -272,6 +350,10 @@ func TestRegexes(t *testing.T) {
 		{`3ffe:2a00:100:7031::1`, nil},
 		{`test.foo.com:8080/path`, nil},
 		{`foo@bar.com`, nil},
+
+		// An IP address in URI host position must be bracketed unless it is IPv4.
+		// https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2
+		//{`http://1080::8:800:200c:417a/path`, nil},
 	})
 }
 


### PR DESCRIPTION
Ref #62

includes changes from #63

`benchstat` vs. master@68fd825f4d226a5b043f697ed9c2c29011c4c9ac

    name                         old time/op    new time/op    delta
    Strict_none-4                  45.7µs ±27%    41.8µs ± 4%     ~     (p=0.315 n=10+8)
    Strict_many-4                  36.0µs ± 4%    36.8µs ± 6%     ~     (p=0.156 n=9+10)
    Relaxed_none-4                 60.8µs ±19%    68.2µs ±17%  +12.19%  (p=0.011 n=10+10)
    Relaxed_many-4                 50.1µs ± 7%    56.8µs ±18%  +13.37%  (p=0.000 n=9+10)
    StrictMatchingScheme_none-4     775ns ±39%     743ns ±24%     ~     (p=0.739 n=10+10)
    StrictMatchingScheme_many-4    1.77µs ± 9%    1.95µs ±17%     ~     (p=0.053 n=9+10)

    name                         old speed      new speed      delta
    Strict_none-4                1.73MB/s ±22%  1.87MB/s ± 4%     ~     (p=0.303 n=10+8)
    Strict_many-4                2.69MB/s ± 4%  2.64MB/s ± 6%     ~     (p=0.138 n=9+10)
    Relaxed_none-4               1.29MB/s ±16%  1.16MB/s ±15%  -10.60%  (p=0.011 n=10+10)
    Relaxed_many-4               1.94MB/s ± 6%  1.72MB/s ±16%  -11.34%  (p=0.000 n=9+10)
    StrictMatchingScheme_none-4   103MB/s ±30%   106MB/s ±20%     ~     (p=0.739 n=10+10)
    StrictMatchingScheme_many-4  53.9MB/s ±19%  50.4MB/s ±18%     ~     (p=0.123 n=10+10)

    name                         old alloc/op   new alloc/op   delta
    Strict_none-4                   0.00B          0.00B          ~     (all equal)
    Strict_many-4                    230B ± 7%      233B ± 4%     ~     (p=0.790 n=10+10)
    Relaxed_none-4                 8.80B ±241%     0.00B          ~     (p=0.173 n=10+9)
    Relaxed_many-4                   240B ± 0%      240B ± 0%     ~     (all equal)
    StrictMatchingScheme_none-4     0.00B          0.00B          ~     (all equal)
    StrictMatchingScheme_many-4      192B ± 0%      192B ± 0%     ~     (all equal)

    name                         old allocs/op  new allocs/op  delta
    Strict_none-4                    0.00           0.00          ~     (all equal)
    Strict_many-4                    5.00 ± 0%      5.00 ± 0%     ~     (all equal)
    Relaxed_none-4                   0.00           0.00          ~     (all equal)
    Relaxed_many-4                   6.00 ± 0%      6.00 ± 0%     ~     (all equal)
    StrictMatchingScheme_none-4      0.00           0.00          ~     (all equal)
    StrictMatchingScheme_many-4      3.00 ± 0%      3.00 ± 0%     ~     (all equal)