### PR TITLE
revert "add ‘gemini’ scheme"

### DIFF
--- a/schemes.go
+++ b/schemes.go
@@ -94,7 +94,6 @@ var Schemes = []string{
 	`fm`,
 	`ftp`,
 	`fuchsia-pkg`,
-	`gemini`,
 	`geo`,
 	`gg`,
 	`git`,


### PR DESCRIPTION
The commit edited a generated file, so it is overwritten by `go generate`.
I didn't catch that as I code reviewed on my phone while on a train.

The right place to add it would be `SchemesUnofficial`,
where we add schemes which aren't properly registered and listed yet.
That actually happened in https://github.com/mvdan/xurls/pull/54 already;
we just haven't issued a release yet, so the downstream didn't see it.

Reverts https://github.com/mvdan/xurls/pull/66.