### PR TITLE
Ensure port has at least one number. Fixes #74.

### DIFF
--- a/xurls.go
+++ b/xurls.go
@@ -75,7 +75,7 @@ const (
 		`)`
 	ipv6Addr         = `(?:` + ipv6AddrMinusEmpty + `|::)`
 	ipAddrMinusEmpty = `(?:` + ipv6AddrMinusEmpty + `|\b` + ipv4Addr + `\b)`
-	port             = `(?::[0-9]*)?`
+	port             = `(?::[0-9]+)?`
 )
 
 // AnyScheme can be passed to StrictMatchingScheme to match any possibly valid

--- a/xurls_test.go
+++ b/xurls_test.go
@@ -328,6 +328,7 @@ func TestRegexes(t *testing.T) {
 		{`"foo.com/bar"`, `foo.com/bar`},
 		{`what is foo.com?`, `foo.com`},
 		{`the foo.com!`, `foo.com`},
+		{`check of foo.com: ok`, `foo.com`},
 
 		{`foo@bar`, nil},
 		{`foo@bar.a`, nil},


### PR DESCRIPTION
The existing port regex appears to match a colon followed by 0 or more digits. This change will require 1 or more digits after a colon.