### PR TITLE
fix: ipv6 matching is too lenient

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
 # xurls
 
-[![Go Reference](https://pkg.go.dev/badge/mvdan.cc/xurls/v2.svg)](https://pkg.go.dev/mvdan.cc/xurls/v2)
+> A modified version of [xurls](github.com/mvdan/xurls), with a focus on matching content within user messages that would be clickable in web browsers.
+>
+> In short, this stops a bug with [Fossabot on YouTube](https://fossabot.com), where it accidentally matches multiple YouTube emotes chained together due to `::` being in the string.
+>
+> This seems like desired/intentional behaviour from `xurls`, hence the fork and not contributing back to the package. The package is correct, in relaxed mode, these ARE valid ipv6 addresses! However, this causes problems for this specific use case.
+>
+> Please contribute back and star the original xurls package!
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/aidenwallis/xurls.svg)](https://pkg.go.dev/github.com/aidenwallis/xurls)
 
 Extract urls from text using regular expressions. Requires Go 1.22 or later.
 
 ```go
-import "mvdan.cc/xurls/v2"
+import "github.com/aidenwallis/xurls"
 
 func main() {
 	rxRelaxed := xurls.Relaxed()
@@ -29,7 +37,7 @@ Any subsequent calls will use the same regular expression pointers.
 
 To install the tool globally:
 
-	go install mvdan.cc/xurls/v2/cmd/xurls@latest
+	go install github.com/aidenwallis/xurls/cmd/xurls@latest
 
 ```shell
 $ echo "Do gophers live in http://golang.org?" | xurls

--- a/cmd/xurls/main.go
+++ b/cmd/xurls/main.go
@@ -21,7 +21,7 @@ import (
 
 	"golang.org/x/mod/module"
 
-	"mvdan.cc/xurls/v2"
+	"github.com/aidenwallis/xurls"
 )
 
 var (

--- a/example_test.go
+++ b/example_test.go
@@ -6,7 +6,7 @@ package xurls_test
 import (
 	"fmt"
 
-	"mvdan.cc/xurls/v2"
+	"github.com/aidenwallis/xurls"
 )
 
 func Example() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module mvdan.cc/xurls/v2
+module github.com/aidenwallis/xurls
 
 go 1.22
 

--- a/xurls.go
+++ b/xurls.go
@@ -165,7 +165,7 @@ func relaxedExp() string {
 	hostName := `(?:` + domain + `|\[` + ipv6Addr + `\]|\b` + ipv4Addr + `\b)`
 	webURL := hostName + port + `(?:/` + pathCont + `|/)?`
 	email := `(?P<relaxedEmail>[a-zA-Z0-9._%\-+]+@` + domain + `)`
-	return strictExp() + `|` + webURL + `|` + email + `|` + ipv6AddrMinusEmpty
+	return strictExp() + `|` + webURL + `|` + email
 }
 
 // Strict produces a regexp that matches any URL with a scheme in either the

--- a/xurls_test.go
+++ b/xurls_test.go
@@ -199,6 +199,11 @@ var constantTestCases = []testCase{
 func TestRegexes(t *testing.T) {
 	doTest(t, "Relaxed", Relaxed(), constantTestCases)
 	doTest(t, "Strict", Strict(), constantTestCases)
+	doTest(t, "Relaxed_YouTubeEmotes", Relaxed(), []testCase{
+		// Shoul not match YouTube emotes: the YouTube API contains emotes in a plain text format with zero metadata allowing us to understand
+		// the placement of said emotes. This change locks ipv6 to only match through `[<ipv6>]`, which is required for web browsers to click with anyways.
+		{`:face-orange-biting-nails::face-orange-biting-nails::face-orange-biting-nails::face-orange-biting-nails::face-orange-biting-nails:`, nil},
+	})
 	doTest(t, "Relaxed2", Relaxed(), []testCase{
 		{`foo.a`, nil},
 		{`foo.com`, true},
@@ -229,73 +234,73 @@ func TestRegexes(t *testing.T) {
 		{`foo@1.2.3.4`, `1.2.3.4`},
 
 		// https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
-		{`::1`, true},
+		{`[::1]`, true},
 		//{`::`, true},
-		{`::ffff:0:0`, true},
-		{`64:ff9b::`, true},
-		{`64:ff9b:1::`, true},
-		{`100::`, true},
-		{`2001::`, true},
-		{`2001:1::1`, true},
-		{`2001:1::2`, true},
-		{`2001:2::`, true},
-		{`2001:3::`, true},
-		{`2001:4:112::`, true},
-		{`2001:10::`, true},
-		{`2001:20::`, true},
-		{`2001:db8::`, true},
-		{`2002::`, true},
-		{`2620:4f:8000::`, true},
-		{`fc00::`, true},
-		{`fe80::`, true},
+		{`[::ffff:0:0]`, true},
+		{`[64:ff9b::]`, true},
+		{`[64:ff9b:1::]`, true},
+		{`[100::]`, true},
+		{`[2001::]`, true},
+		{`[2001:1::1]`, true},
+		{`[2001:1::2]`, true},
+		{`[2001:2::]`, true},
+		{`[2001:3::]`, true},
+		{`[2001:4:112::]`, true},
+		{`[2001:10::]`, true},
+		{`[2001:20::]`, true},
+		{`[2001:db8::]`, true},
+		{`[2002::]`, true},
+		{`[2620:4f:8000::]`, true},
+		{`[fc00::]`, true},
+		{`[fe80::]`, true},
 
 		// https://datatracker.ietf.org/doc/html/rfc4291#section-2.2
-		{`ABCD:EF01:2345:6789:ABCD:EF01:2345:6789`, true},
-		{`2001:DB8:0:0:8:800:200C:417A`, true},
-		{`2001:DB8:0:0:8:800:200C:417A`, true}, // a unicast address
-		{`FF01:0:0:0:0:0:0:101`, true},         // a multicast address
-		{`0:0:0:0:0:0:0:1`, true},              // the loopback address
-		{`0:0:0:0:0:0:0:0`, true},              // the unspecified address
-		{`2001:DB8::8:800:200C:417A`, true},    // a unicast address
-		{`FF01::101`, true},                    // a multicast address
-		{`::1`, true},                          // the loopback address
+		{`[ABCD:EF01:2345:6789:ABCD:EF01:2345:6789]`, true},
+		{`[2001:DB8:0:0:8:800:200C:417A]`, true},
+		{`[2001:DB8:0:0:8:800:200C:417A]`, true}, // a unicast address
+		{`[FF01:0:0:0:0:0:0:101]`, true},         // a multicast address
+		{`[0:0:0:0:0:0:0:1]`, true},              // the loopback address
+		{`[0:0:0:0:0:0:0:0]`, true},              // the unspecified address
+		{`[2001:DB8::8:800:200C:417A]`, true},    // a unicast address
+		{`[FF01::101]`, true},                    // a multicast address
+		{`[::1]`, true},                          // the loopback address
 		//{`::`, true},                         // the unspecified address
 		{`::`, nil},
-		{`0:0:0:0:0:0:13.1.68.3`, true},
-		{`0:0:0:0:0:FFFF:129.144.52.38`, true},
-		{`::13.1.68.3`, true},
-		{`::FFFF:129.144.52.38`, true},
+		{`[0:0:0:0:0:0:13.1.68.3]`, true},
+		{`[0:0:0:0:0:FFFF:129.144.52.38]`, true},
+		{`[::13.1.68.3]`, true},
+		{`[::FFFF:129.144.52.38]`, true},
 
 		// https://datatracker.ietf.org/doc/html/rfc5952#section-1
-		{`2001:db8:0:0:1:0:0:1`, true},
-		{`2001:0db8:0:0:1:0:0:1`, true},
-		{`2001:db8::1:0:0:1`, true},
-		{`2001:db8::0:1:0:0:1`, true},
-		{`2001:0db8::1:0:0:1`, true},
-		{`2001:db8:0:0:1::1`, true},
-		{`2001:db8:0000:0:1::1`, true},
-		{`2001:DB8:0:0:1::1`, true},
+		{`[2001:db8:0:0:1:0:0:1]`, true},
+		{`[2001:0db8:0:0:1:0:0:1]`, true},
+		{`[2001:db8::1:0:0:1]`, true},
+		{`[2001:db8::0:1:0:0:1]`, true},
+		{`[2001:0db8::1:0:0:1]`, true},
+		{`[2001:db8:0:0:1::1]`, true},
+		{`[2001:db8:0000:0:1::1]`, true},
+		{`[2001:DB8:0:0:1::1]`, true},
 
 		// https://datatracker.ietf.org/doc/html/rfc5952#section-2.1
-		{`2001:db8:aaaa:bbbb:cccc:dddd:eeee:0001`, true},
-		{`2001:db8:aaaa:bbbb:cccc:dddd:eeee:001`, true},
-		{`2001:db8:aaaa:bbbb:cccc:dddd:eeee:01`, true},
-		{`2001:db8:aaaa:bbbb:cccc:dddd:eeee:1`, true},
+		{`[2001:db8:aaaa:bbbb:cccc:dddd:eeee:0001]`, true},
+		{`[2001:db8:aaaa:bbbb:cccc:dddd:eeee:001]`, true},
+		{`[2001:db8:aaaa:bbbb:cccc:dddd:eeee:01]`, true},
+		{`[2001:db8:aaaa:bbbb:cccc:dddd:eeee:1]`, true},
 
 		// https://datatracker.ietf.org/doc/html/rfc5952#section-2.2
-		{`2001:db8:aaaa:bbbb:cccc:dddd::1`, true},
-		{`2001:db8:aaaa:bbbb:cccc:dddd:0:1`, true},
-		{`2001:db8:0:0:0::1`, true},
-		{`2001:db8:0:0::1`, true},
-		{`2001:db8:0::1`, true},
-		{`2001:db8::1`, true},
-		{`2001:db8::aaaa:0:0:1`, true},
-		{`2001:db8:0:0:aaaa::1`, true},
+		{`[2001:db8:aaaa:bbbb:cccc:dddd::1]`, true},
+		{`[2001:db8:aaaa:bbbb:cccc:dddd:0:1]`, true},
+		{`[2001:db8:0:0:0::1]`, true},
+		{`[2001:db8:0:0::1]`, true},
+		{`[2001:db8:0::1]`, true},
+		{`[2001:db8::1]`, true},
+		{`[2001:db8::aaaa:0:0:1]`, true},
+		{`[2001:db8:0:0:aaaa::1]`, true},
 
 		// https://datatracker.ietf.org/doc/html/rfc5952#section-2.3
-		{`2001:db8:aaaa:bbbb:cccc:dddd:eeee:aaaa`, true},
-		{`2001:db8:aaaa:bbbb:cccc:dddd:eeee:AAAA`, true},
-		{`2001:db8:aaaa:bbbb:cccc:dddd:eeee:AaAa`, true},
+		{`[2001:db8:aaaa:bbbb:cccc:dddd:eeee:aaaa]`, true},
+		{`[2001:db8:aaaa:bbbb:cccc:dddd:eeee:AAAA]`, true},
+		{`[2001:db8:aaaa:bbbb:cccc:dddd:eeee:AaAa]`, true},
 
 		// An IP address in URI host position must be bracketed unless it is IPv4.
 		// https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2


### PR DESCRIPTION
This fork exists to address the case where `xurls` **correctly** matches `::<a-f>` in `Relaxed()`. While this is correct functionality as this is valid IPv6, it causes issues for [Fossabot](https://fossabot.com).

This issue primarily exists in YouTube chat, where multiple emotes chained together provide Fossabot with the following output:

```
:face-orange-biting-nails::face-orange-biting-nails::face-orange-biting-nails::face-orange-biting-nails::face-orange-biting-nails:
```

If you notice in this string, the use of `::f` etc is used, which **is** valid IPv6. However, this is too lenient in our use case.

This modification requires the input to be wrapped with `[]`, which is a requirement for making these URLs clickable in web browsers anyways, which is fine for our case.