### PR TITLE
Add `matrix:` to SchemesNoAuthority

### DIFF
--- a/xurls.go
+++ b/xurls.go
@@ -92,6 +92,7 @@ var SchemesNoAuthority = []string{
 	`geo`,     // Geographic location
 	`magnet`,  // Torrent magnets
 	`mailto`,  // Mail
+	`matrix`,  // Matrix
 	`mid`,     // Message-ID
 	`sms`,     // SMS
 	`tel`,     // Telephone


### PR DESCRIPTION
`matrix:` URIs don't use the authority part, as per https://spec.matrix.org/v1.12/appendices/#matrix-uri-scheme

> Currently, the `authority` and `fragment` are unused by this specification, though are reserved for future use.